### PR TITLE
feat: Add task card thumbnails with live element highlighting

### DIFF
--- a/moat-chrome/moat.css
+++ b/moat-chrome/moat.css
@@ -95,27 +95,6 @@ body.float-comment-mode * {
   min-width: 20px !important;
 }
 
-.float-highlight-pulse {
-  animation: float-pulse 2s ease-in-out !important;
-}
-
-@keyframes float-pulse {
-  0% {
-    outline: 2px solid #3B82F6;
-    outline-offset: 2px;
-    background-color: rgba(59, 130, 246, 0.1);
-  }
-  50% {
-    outline: 4px solid #3B82F6;
-    outline-offset: 4px;
-    background-color: rgba(59, 130, 246, 0.2);
-  }
-  100% {
-    outline: 2px solid #3B82F6;
-    outline-offset: 2px;
-    background-color: rgba(59, 130, 246, 0.1);
-  }
-}
 
 /* ========== HEADER NOTIFICATIONS ========== */
 .float-header-notifications {
@@ -1379,13 +1358,29 @@ body.float-comment-mode * {
   background: var(--moat-bg-secondary);
   border: 1px solid var(--moat-border);
   border-radius: 8px;
-  padding: 8px 12px;
+  padding: 8px;
   margin-bottom: 12px;
-  cursor: grab;
+  cursor: default;
   transition: all 0.2s;
   min-height: 120px;
+}
+
+/* Two-column layout: content area on left, thumbnail on right */
+.float-moat-item-layout {
+  display: flex;
+  gap: 12px;
+  align-items: stretch; /* Make children fill height */
+  width: 100%;
+  min-height: 104px; /* min-height minus padding (120px - 16px) */
+}
+
+/* Content area contains all text elements */
+.float-moat-item-content-area {
+  flex: 1;
+  min-width: 0; /* Allow text truncation */
   display: flex;
   flex-direction: column;
+  overflow: hidden; /* Ensure content doesn't overflow */
 }
 
 /* Hover effect removed per user request */
@@ -1395,13 +1390,62 @@ body.float-comment-mode * {
   cursor: grabbing;
 }
 
-/* Row 1: Status, Timestamp | Close button */
+/* Row 1: Status, Timestamp | Thumbnail/Close button */
 .float-moat-item-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
+}
+
+/* Thumbnail container with hover X button */
+.float-moat-thumbnail-container {
+  position: relative;
+  width: 114px;
+  flex-shrink: 0;
+  border-radius: 6px;
+  overflow: visible;
+  background: var(--moat-bg-tertiary);
+  border: 1px solid var(--moat-border);
+  align-self: stretch; /* Fill full height of card */
+}
+
+.float-moat-thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 6px;
+  display: block;
+}
+
+.float-moat-thumbnail-overlay {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: var(--moat-bg-primary);
+  border: 1px solid var(--moat-border);
+  color: var(--moat-text-muted);
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: all 0.2s;
+  box-shadow: 0 1px 3px var(--moat-shadow);
+}
+
+.float-moat-item:hover .float-moat-thumbnail-overlay {
+  display: flex;
+}
+
+.float-moat-thumbnail-close {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
 }
 
 .float-moat-status-and-time {
@@ -1409,23 +1453,15 @@ body.float-comment-mode * {
   align-items: center;
   gap: 8px;
   flex: 1;
-}
-
-.float-moat-status-text {
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--moat-text-tertiary);
-  background: var(--moat-bg-tertiary);
-  padding: 3px 8px;
-  border-radius: 12px;
-  white-space: nowrap;
-  text-transform: lowercase;
+  overflow: hidden;
 }
 
 .float-moat-time {
   font-size: 12px;
   font-weight: 500;
   color: var(--moat-text-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .float-moat-remove {
@@ -1443,6 +1479,11 @@ body.float-comment-mode * {
   justify-content: center;
   padding: 0;
   flex-shrink: 0;
+  opacity: 0;
+}
+
+.float-moat-item:hover .float-moat-remove {
+  opacity: 1;
 }
 
 .float-moat-remove:hover {
@@ -1450,55 +1491,38 @@ body.float-comment-mode * {
   color: var(--moat-error);
 }
 
-/* Row 2: User comment (lighter weight, closer to black) */
+/* User comment (main content text) */
 .float-moat-content {
   font-size: 14px;
   font-weight: 400;
   color: var(--moat-text-secondary);
-  margin-bottom: 6px;
-  line-height: 1.3;
+  line-height: 1.4;
+  overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  overflow: hidden;
-  flex-grow: 1;
+  width: 100%;
+  margin-bottom: 6px;
+  flex-shrink: 0;
 }
 
-/* Row 3 & 4: Divider line + Target element info */
-.float-moat-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 12px;
-  color: var(--moat-text-tertiary);
-  margin: auto 0 0 0;
-  padding: 8px 0 0 0;
-  border-top: 1px solid var(--moat-border-light);
-}
-
-.float-moat-target {
-  font-size: 12px;
-  font-weight: 400;
-  color: var(--moat-text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-  margin-right: 8px;
-}
-
+/* Element selector as footer */
 .float-moat-selector {
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
   background: var(--moat-bg-tertiary);
   color: var(--moat-text-tertiary);
   padding: 2px 6px;
   border-radius: 4px;
-  font-size: 12px;
-  max-width: 120px;
+  font-size: 11px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   flex-shrink: 0;
+  min-width: 0;
+  max-width: 150px;
+  margin-top: auto; /* Push to bottom */
+  margin-bottom: 0; /* Use only card padding for bottom spacing */
+  align-self: flex-start; /* Align to left */
 }
 
 /* Task 3.6: Enhanced status indicators */


### PR DESCRIPTION
- Add contextual screenshot thumbnails (114x64px) with 100px padding
- Implement click-based focus positioning in thumbnails using object-position
- Add DOM overlay highlighting system for smooth annotation workflow
- Add live element preview on hover - shows blue overlay on page element
- Replace pulsing CSS effects with clean DOM overlay transitions
- Show remove button on card hover for better UX
- Support both taskStore and legacy localStorage systems
- Auto-scroll elements into view when off-screen
- Clean up overlays on mouse leave, scroll, and sidebar close

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds click-focused screenshot thumbnails to task cards and switches to DOM overlay-based element highlighting with pre-captured annotated screenshots.
> 
> - **Content capture (`moat-chrome/content_script.js`)**:
>   - Use DOM overlay for element highlight; replace pulse effect with `hoverOverlay` element and cleanup on exit.
>   - Pre-capture annotated screenshots via `html2canvas` (with 100px padding) when opening the comment box; store `screenshotData` and `screenshotViewport` on the box.
>   - Include `clickPosition` and `screenshotViewport` in saved annotations; reuse pre-captured screenshot on submit.
> - **Sidebar/Tasks (`moat-chrome/moat.js`)**:
>   - Add thumbnail loading/cache from `.moat/screenshots` using File System Access API; revoke URLs on cleanup.
>   - Render task cards with right-side thumbnail; compute `object-position` from `clickPosition` within `screenshotViewport` for focus.
>   - Add hover/click live element preview using a page-level DOM overlay; auto-scroll into view and remove overlays on mouseleave/scroll/hide.
>   - Support removal via thumbnail overlay button; wire up listeners for both new TaskStore and legacy localStorage.
> - **Styles (`moat-chrome/moat.css`)**:
>   - Remove pulsing highlight CSS; add styles for two-column task layout, thumbnail container/image, and hover close overlay.
>   - UI tweaks: padding/cursor adjustments, truncated selector styling, hover-reveal remove button, and minor layout polish.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b14d24d9ecb193231af4b8cce7f4899f497a3a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->