### PR TITLE
Fix: Restrict 'C' key activation to tabs with visible Drawbridge sidebar

### DIFF
--- a/moat-chrome/content_script.js
+++ b/moat-chrome/content_script.js
@@ -3238,8 +3238,21 @@ JSON stores relative paths like \`./screenshots/file.png\`, but actual files are
 
   // Listen for keyboard events
   document.addEventListener('keydown', (e) => {
-    // Enter comment mode with 'C' key (updated from 'f')
+    // Exit comment mode with Escape (works on all tabs, even if not visible)
+    if (e.key === 'Escape' && commentMode) {
+      e.preventDefault();
+      exitCommentMode();
+      return;
+    }
+    
+    // 'C' key should ONLY work when sidebar is visible on the active tab
     if ((e.key === 'C' || e.key === 'c') && !commentMode && !e.target.matches('input, textarea')) {
+      // Check if tab is visible AND sidebar is open
+      const sidebarVisible = window.Moat && window.Moat.isSidebarVisible ? window.Moat.isSidebarVisible() : false;
+      if (document.hidden || !sidebarVisible) {
+        return; // Ignore the keystroke
+      }
+      
       e.preventDefault();
       
       // Dispatch event to remove persistent notification
@@ -3253,12 +3266,6 @@ JSON stores relative paths like \`./screenshots/file.png\`, but actual files are
       }
       
       enterCommentMode();
-    }
-    
-    // Exit comment mode with Escape
-    if (e.key === 'Escape' && commentMode) {
-      e.preventDefault();
-      exitCommentMode();
     }
     
     // Toggle sidebar with Cmd+Shift+F

--- a/moat-chrome/moat.js
+++ b/moat-chrome/moat.js
@@ -3485,6 +3485,11 @@
     return true;
   }
 
+  // Export to global scope for content script access
+  window.Moat = {
+    isSidebarVisible: () => isVisible,
+  };
+
   // Export to global scope for debugging and manual sync
   window.MoatDebug = {
     exportAnnotations,


### PR DESCRIPTION
Fixing an issue that would enable commenting on other tabs not currently using the drawbridge plugin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts 'C' to enter comment mode only on the active tab when the sidebar is visible, adds global Escape-to-exit handling, and exposes `window.Moat.isSidebarVisible()` for the content script.
> 
> - **Keyboard handling (`moat-chrome/content_script.js`)**:
>   - Require active tab and visible sidebar to enter comment mode via `C`.
>   - Handle `Escape` to exit comment mode (works across tabs).
> - **Global API (`moat-chrome/moat.js`)**:
>   - Expose `window.Moat.isSidebarVisible()` to report sidebar visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb18d48c309e7af655b566b1f9c68f28245f1a83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->