### PR TITLE
Fix toolbar overflow when docked to left or right

### DIFF
--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -1840,9 +1840,6 @@ body.float-drawing-mode * {
 }
 
 /* Compact styling for left position (same as right) */
-.float-moat.float-moat-left .float-moat-new-comment-container {
-  /* Spacing handled by parent gap */
-}
 
 /* New Project Dropdown Styling */
 .float-moat-project-status-container {


### PR DESCRIPTION
- Add min-width: 0 and overflow: hidden to .float-moat-right-controls for left/right positions
- Add flex-shrink: 0 to button containers to prevent compression
- Ensures toolbar buttons stay within bounds and don't overflow when space is constrained

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Constrain and prevent flex-shrink of toolbar controls in left/right docked modes to keep buttons within bounds.
> 
> - **CSS (moat toolbar, left/right positions)**:
>   - Add `min-width: 0` and `overflow: hidden` to `*.float-moat-right-controls` within `.float-moat-right` and `.float-moat-left`.
>   - Prevent compression with `flex-shrink: 0` on `*.float-moat-project-status-container`, `*.float-moat-actions`, and `*.float-moat-new-comment-container` for both sides.
>   - Minor compact sizing retained (no functional changes beyond overflow/shrink behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1c1cd4b086883b7eb2b1b471bc1e409819e1435. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->