### PR TITLE
fix: Ensure Tools dropdown remains visible when docked left/right

### DIFF
--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -1779,14 +1779,17 @@ body.float-drawing-mode * {
 .float-moat.float-moat-right .float-moat-new-comment-container {
   /* Spacing handled by parent gap */
   flex-shrink: 0;
+  min-width: 0;
 }
 
 .float-moat.float-moat-right .float-moat-tools-dropdown {
   max-width: 60px;
+  min-width: 32px; /* Ensure button is always visible with icon */
   padding: 4px 8px;
   height: 28px;
   font-size: 11px;
   gap: 4px;
+  flex-shrink: 0; /* Prevent button from shrinking */
 }
 
 .float-moat.float-moat-right .float-tools-text {
@@ -1811,14 +1814,17 @@ body.float-drawing-mode * {
 .float-moat.float-moat-left .float-moat-new-comment-container {
   /* Spacing handled by parent gap */
   flex-shrink: 0;
+  min-width: 0;
 }
 
 .float-moat.float-moat-left .float-moat-tools-dropdown {
   max-width: 60px;
+  min-width: 32px; /* Ensure button is always visible with icon */
   padding: 4px 8px;
   height: 28px;
   font-size: 11px;
   gap: 4px;
+  flex-shrink: 0; /* Prevent button from shrinking */
 }
 
 .float-moat.float-moat-left .float-tools-text {


### PR DESCRIPTION
- Add min-width: 32px to Tools dropdown button to prevent it from being clipped
- Add flex-shrink: 0 to prevent button from shrinking below minimum size
- Add min-width: 0 to container for proper flex behavior
- Fixes issue where Tools dropdown disappeared when toolbar overflow fix was applied

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents the Tools dropdown from shrinking or being clipped when docked left/right by enforcing minimum widths and disabling flex shrink.
> 
> - **CSS (`chrome-extension/moat.css`)**
>   - **Left/Right docked toolbar**:
>     - Add `min-width: 0` to `*.float-moat-new-comment-container` for proper flex behavior.
>     - Add `min-width: 32px` and `flex-shrink: 0` to `*.float-moat-tools-dropdown` to keep the button visible with its icon.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb3c6a341ebe86e02db41d1f4d51fbc11f9c1695. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->