### PR TITLE
Fix MoatPersistence.isSupported() failing in content script context

### DIFF
--- a/chrome-extension/content_script.js
+++ b/chrome-extension/content_script.js
@@ -625,7 +625,7 @@
     
     // Check if persistence is supported
     if (!MoatPersistence.isSupported()) {
-      console.warn('⚠️ Moat: Persistence not supported (missing File System API or IndexedDB)');
+      console.warn('⚠️ Moat: Persistence not supported (missing IndexedDB)');
       await checkLegacyConnection();
       return;
     }

--- a/chrome-extension/utils/persistence.js
+++ b/chrome-extension/utils/persistence.js
@@ -348,10 +348,12 @@ class MoatPersistence {
   }
 
   /**
-   * Check if File System Access API is supported
+   * Check if persistence storage (IndexedDB) is supported.
+   * Note: showDirectoryPicker is checked separately where it's actually called
+   * (e.g., setupProject) since it may not be available in content script contexts.
    */
   static isSupported() {
-    return 'showDirectoryPicker' in window && 'indexedDB' in window;
+    return 'indexedDB' in window;
   }
 }
 

--- a/chrome-extension/utils/persistence.test.js
+++ b/chrome-extension/utils/persistence.test.js
@@ -165,15 +165,23 @@ describe('MoatPersistence', () => {
   });
 
   test('should support feature detection', () => {
-    // Mock supported environment
-    global.window.showDirectoryPicker = () => {};
+    // Mock supported environment (only IndexedDB needed)
     global.indexedDB = {};
-    
+
     expect(global.window.MoatPersistence.isSupported()).toBe(true);
-    
-    // Mock unsupported environment
-    delete global.window.showDirectoryPicker;
+
+    // Mock unsupported environment (no IndexedDB)
+    delete global.indexedDB;
     expect(global.window.MoatPersistence.isSupported()).toBe(false);
+  });
+
+  test('should be supported even without showDirectoryPicker', () => {
+    // Persistence only needs IndexedDB; showDirectoryPicker is checked
+    // separately where it's actually called (e.g., setupProject)
+    global.indexedDB = {};
+    delete global.window.showDirectoryPicker;
+
+    expect(global.window.MoatPersistence.isSupported()).toBe(true);
   });
 
   test('should initialize IndexedDB correctly', async () => {


### PR DESCRIPTION
## Summary
- `MoatPersistence.isSupported()` was checking for both `showDirectoryPicker` AND `indexedDB`, but `showDirectoryPicker` is not available in Chrome MV3 content script isolated world contexts
- The `MoatPersistence` class only uses IndexedDB — it never calls `showDirectoryPicker` — so the check was overly strict and blocked the entire persistence system
- `showDirectoryPicker` is already independently guarded in `setupProject()` (line 933) where it's actually called
- Fixed `isSupported()` to only check for `indexedDB`, updated the log message, and added a test case for the content script scenario

## Root Cause
In Chrome extension content scripts (isolated world), `window.showDirectoryPicker` is `undefined`. The `isSupported()` gate caused `initializeProject()` to bail out immediately and fall through to `checkLegacyConnection()`, which also fails — resulting in the error:
```
Moat: Persistence not supported (missing File System API or IndexedDB)
```

## Test plan
- [x] Verified `isSupported()` returns `true` when only `indexedDB` is present (no `showDirectoryPicker`)
- [x] Confirmed all pre-existing tests still pass (note: 13 tests in persistence.test.js have pre-existing failures from a mock setup issue unrelated to this change)
- [ ] Manual test: load extension in Chrome, verify persistence initializes on a page

🤖 Generated with [Claude Code](https://claude.com/claude-code)