### PR TITLE
Update stale getTasks() doc comment in taskStore

### DIFF
--- a/chrome-extension/utils/taskStore.js
+++ b/chrome-extension/utils/taskStore.js
@@ -119,7 +119,8 @@ class TaskStore {
     }
 
     /**
-     * Load tasks from memory (for now - file operations will be added in task 1.5)
+     * Get in-memory tasks sorted by timestamp (newest first).
+     * Use loadTasksFromFile() to refresh from disk.
      * @returns {Array} Array of task objects
      */
     getTasks() {


### PR DESCRIPTION
The comment claimed file operations would be added later, but
loadTasksFromFile/saveTasksToFile have since been implemented in the
same class. Replace with an accurate description that points readers
to loadTasksFromFile() for refreshing from disk.

https://claude.ai/code/session_01LAt1xGDssrbzxugasVnArF