### PR TITLE
Add collapsible Drawbridge side rail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,13 @@ coverage/
 .moat/
 .claude/
 
+# Local agent coordination notes
+AGENT_NOTES.md
+TASKS.md
+ROADMAP.md
+*-ROADMAP.md
+*-DOGFOOD-BUGS.md
+
 # Media files and demo assets (hosted externally)
 _media/
 demo/images/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Tasks appear in the drawer and sync to your connected project.
 
 ![Drawbridge rectangle annotation](https://github.com/breschio/drawbridge-media/raw/main/drawbridge-rectangle.gif)
 
+## Drawer Layout
+
+Drawbridge can dock to the bottom, left, or right side of the viewport from the More menu. Use the chevron button to collapse or expand the drawer.
+
+When collapsed on the left or right side, Drawbridge becomes a slim rail with the project button, tools button, and color-coded task counts for `to do`, `doing`, and `done`. The chevron points in the direction the drawer will collapse or expand.
+
 ## Process Tasks
 
 In an AI coding tool, run:

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -200,7 +200,7 @@ Moat can now select and annotate any element on the page:
 
 ## 📤 Export Format
 
-Annotations are exported in MCP-compatible JSON:
+Annotations are exported as Drawbridge task JSON:
 
 ```json
 {

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -30,7 +30,7 @@
   --moat-notification-bg: #1f2937;
   --moat-notification-text: #ffffff;
   --moat-collapsed-bar-size: 49px;
-  --moat-collapsed-rail-size: 72px;
+  --moat-collapsed-rail-size: 56px;
   
   /* Scrollbar colors */
   --moat-scrollbar-track: transparent;
@@ -571,11 +571,11 @@ body.float-drawing-mode * {
   width: 100%;
   height: 100vh;
   min-height: 100vh;
-  padding: 12px 10px;
+  padding: 10px 7px;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   border-bottom: none;
 }
 
@@ -630,43 +630,50 @@ body.float-drawing-mode * {
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-group,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-group {
   width: 100%;
-  padding: 3px;
-  gap: 2px;
+  padding: 0;
+  gap: 8px;
   flex-direction: column;
-  background: var(--moat-bg-tertiary);
-  border: 1px solid var(--moat-border);
-  border-radius: 8px;
-  box-shadow: 0 1px 2px var(--moat-shadow);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-btn,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-btn {
   width: 100%;
-  height: 34px;
-  padding: 0 3px;
+  height: 40px;
+  padding: 0;
   flex: none;
-  font-size: 10px;
-  line-height: 1.05;
-  border: none;
-  border-radius: 5px;
+  font-size: 0;
+  line-height: 1;
+  border: 1px solid transparent;
+  border-radius: 8px;
   box-shadow: none;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-btn.float-tab-active,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-btn.float-tab-active {
-  background: var(--moat-bg-primary);
+  background: var(--moat-bg-secondary);
+  border-color: var(--moat-border);
   box-shadow: 0 1px 3px var(--moat-shadow);
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-badge,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-badge {
-  position: absolute;
-  top: 2px;
-  right: 2px;
-  min-width: 12px;
-  padding: 1px 3px;
-  font-size: 8px;
-  line-height: 9px;
+  position: static;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 999px;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 28px;
+  color: #ffffff;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-tools-dropdown,
@@ -678,10 +685,10 @@ body.float-drawing-mode * {
   width: 100%;
   max-width: none;
   min-width: 0;
-  height: 42px;
+  height: 40px;
   padding: 0;
   justify-content: center;
-  border-radius: 7px;
+  border-radius: 8px;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tools-text,
@@ -715,8 +722,8 @@ body.float-drawing-mode * {
 .float-moat.float-moat-left.float-moat-collapsed .float-tools-icon,
 .float-moat.float-moat-right.float-moat-collapsed .float-project-folder-icon,
 .float-moat.float-moat-left.float-moat-collapsed .float-project-folder-icon {
-  width: 15px;
-  height: 15px;
+  width: 16px;
+  height: 16px;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-project-indicator,

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -1503,6 +1503,13 @@ body.float-drawing-mode * {
   overflow: hidden;
 }
 
+.float-moat-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
 .float-moat-time {
   font-size: 12px;
   font-weight: 500;
@@ -1511,6 +1518,7 @@ body.float-drawing-mode * {
   flex-shrink: 0;
 }
 
+.float-moat-action-btn,
 .float-moat-remove {
   background: transparent;
   border: 1px solid var(--moat-border);
@@ -1529,8 +1537,14 @@ body.float-drawing-mode * {
   opacity: 0;
 }
 
+.float-moat-item:hover .float-moat-action-btn,
 .float-moat-item:hover .float-moat-remove {
   opacity: 1;
+}
+
+.float-moat-action-btn:hover {
+  background: var(--moat-bg-tertiary);
+  color: var(--moat-text-primary);
 }
 
 .float-moat-remove:hover {
@@ -2059,6 +2073,20 @@ body.float-drawing-mode * {
   box-sizing: border-box;
 }
 
+.float-badge.delete-completed-badge {
+  background: #DC2626;
+  color: white;
+  min-width: 20px;
+  min-height: 20px;
+  padding: 0 6px;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  height: 20px;
+  border-radius: 10px;
+  box-sizing: border-box;
+}
+
 /* More Menu */
 .float-more-menu {
   position: fixed;
@@ -2256,6 +2284,111 @@ body.float-drawing-mode * {
 
 .float-modal-button-danger:hover {
   background: #B91C1C;
+}
+
+.float-task-detail-modal {
+  max-width: 640px;
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+}
+
+.float-task-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.float-task-detail-header h2 {
+  margin: 0;
+  color: var(--moat-text-primary);
+  font-size: 18px;
+  line-height: 1.3;
+}
+
+.float-task-detail-close {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--moat-border);
+  border-radius: 6px;
+  background: var(--moat-bg-secondary);
+  color: var(--moat-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.float-task-detail-close:hover {
+  color: var(--moat-text-primary);
+  background: var(--moat-bg-tertiary);
+}
+
+.float-task-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.float-task-detail-grid > div {
+  border: 1px solid var(--moat-border);
+  border-radius: 8px;
+  background: var(--moat-bg-secondary);
+  padding: 10px;
+  min-width: 0;
+}
+
+.float-task-detail-grid span,
+.float-task-detail-label {
+  display: block;
+  color: var(--moat-text-tertiary);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.float-task-detail-grid strong,
+.float-task-detail-grid code {
+  color: var(--moat-text-primary);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.float-task-detail-text,
+.float-task-detail-pre,
+.float-task-detail-json pre {
+  border: 1px solid var(--moat-border);
+  border-radius: 8px;
+  background: var(--moat-bg-secondary);
+  color: var(--moat-text-primary);
+  padding: 12px;
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin: 0 0 16px 0;
+}
+
+.float-task-detail-json {
+  margin-bottom: 16px;
+  color: var(--moat-text-secondary);
+}
+
+.float-task-detail-json summary {
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+@media (max-width: 520px) {
+  .float-task-detail-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Float Badge styles removed - badge feature disabled */

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -705,7 +705,14 @@ body.float-drawing-mode * {
   font-weight: 700;
   line-height: 22px;
   color: #ffffff;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-tab-badge {
   transform: translateX(4px);
+}
+
+.float-moat.float-moat-left.float-moat-collapsed .float-tab-badge {
+  transform: translateX(0);
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-tools-dropdown,

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -30,6 +30,7 @@
   --moat-notification-bg: #1f2937;
   --moat-notification-text: #ffffff;
   --moat-collapsed-bar-size: 49px;
+  --moat-collapsed-rail-size: 72px;
   
   /* Scrollbar colors */
   --moat-scrollbar-track: transparent;
@@ -514,8 +515,6 @@ body.float-drawing-mode * {
 }
 
 .float-moat.float-moat-collapsed .float-moat-queue,
-.float-moat.float-moat-collapsed .float-moat-tabs-header,
-.float-moat.float-moat-collapsed .float-moat-tabs-below-header,
 .float-moat.float-moat-collapsed .float-header-notifications {
   display: none !important;
 }
@@ -527,7 +526,7 @@ body.float-drawing-mode * {
   width: 320px;
   height: 100vh;
   box-shadow: -2px 0 12px rgba(0, 0, 0, 0.1);
-  transition: right 0.3s ease;
+  transition: right 0.3s ease, width 0.3s ease;
 }
 
 .float-moat.float-moat-right.float-moat-visible {
@@ -541,7 +540,7 @@ body.float-drawing-mode * {
   width: 320px;
   height: 100vh;
   box-shadow: 2px 0 12px rgba(0, 0, 0, 0.1);
-  transition: left 0.3s ease;
+  transition: left 0.3s ease, width 0.3s ease;
 }
 
 .float-moat.float-moat-left.float-moat-visible {
@@ -550,9 +549,193 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-right.float-moat-collapsed,
 .float-moat.float-moat-left.float-moat-collapsed {
-  height: var(--moat-collapsed-bar-size);
-  min-height: var(--moat-collapsed-bar-size);
-  max-height: var(--moat-collapsed-bar-size);
+  width: var(--moat-collapsed-rail-size);
+  min-width: var(--moat-collapsed-rail-size);
+  max-width: var(--moat-collapsed-rail-size);
+  height: 100vh;
+  min-height: 100vh;
+  max-height: 100vh;
+  overflow: hidden;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed {
+  box-shadow: -1px 0 8px rgba(0, 0, 0, 0.08);
+}
+
+.float-moat.float-moat-left.float-moat-collapsed {
+  box-shadow: 1px 0 8px rgba(0, 0, 0, 0.08);
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-top-bar,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-top-bar {
+  width: 100%;
+  height: 100vh;
+  min-height: 100vh;
+  padding: 12px 10px;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 12px;
+  border-bottom: none;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-top-bar {
+  border-left: 1px solid var(--moat-border);
+}
+
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-top-bar {
+  border-right: 1px solid var(--moat-border);
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-header,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-header,
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-right-controls,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-right-controls,
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-new-comment-container,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-new-comment-container,
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-project-status-container,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-project-status-container {
+  width: 100%;
+  max-width: none;
+  flex: none;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-header h3,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-header h3 {
+  width: 100%;
+  height: 40px;
+  justify-content: center;
+  align-items: center;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-right-controls,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-right-controls {
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  min-height: 0;
+  overflow: visible;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-tabs-header,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-tabs-header {
+  display: flex !important;
+  width: 100%;
+  flex: none;
+  margin: 0;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-tab-group,
+.float-moat.float-moat-left.float-moat-collapsed .float-tab-group {
+  width: 100%;
+  padding: 3px;
+  gap: 2px;
+  flex-direction: column;
+  background: var(--moat-bg-tertiary);
+  border: 1px solid var(--moat-border);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px var(--moat-shadow);
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-tab-btn,
+.float-moat.float-moat-left.float-moat-collapsed .float-tab-btn {
+  width: 100%;
+  height: 34px;
+  padding: 0 3px;
+  flex: none;
+  font-size: 10px;
+  line-height: 1.05;
+  border: none;
+  border-radius: 5px;
+  box-shadow: none;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-tab-btn.float-tab-active,
+.float-moat.float-moat-left.float-moat-collapsed .float-tab-btn.float-tab-active {
+  background: var(--moat-bg-primary);
+  box-shadow: 0 1px 3px var(--moat-shadow);
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-tab-badge,
+.float-moat.float-moat-left.float-moat-collapsed .float-tab-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 12px;
+  padding: 1px 3px;
+  font-size: 8px;
+  line-height: 9px;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-tools-dropdown,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-tools-dropdown,
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-project-dropdown,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-project-dropdown,
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-actions button,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-actions button {
+  width: 100%;
+  max-width: none;
+  min-width: 0;
+  height: 42px;
+  padding: 0;
+  justify-content: center;
+  border-radius: 7px;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-tools-text,
+.float-moat.float-moat-left.float-moat-collapsed .float-tools-text,
+.float-moat.float-moat-right.float-moat-collapsed .float-tools-divider,
+.float-moat.float-moat-left.float-moat-collapsed .float-tools-divider,
+.float-moat.float-moat-right.float-moat-collapsed .float-tools-chevron,
+.float-moat.float-moat-left.float-moat-collapsed .float-tools-chevron,
+.float-moat.float-moat-right.float-moat-collapsed .float-project-label,
+.float-moat.float-moat-left.float-moat-collapsed .float-project-label,
+.float-moat.float-moat-right.float-moat-collapsed .float-project-divider,
+.float-moat.float-moat-left.float-moat-collapsed .float-project-divider,
+.float-moat.float-moat-right.float-moat-collapsed .float-project-chevron,
+.float-moat.float-moat-left.float-moat-collapsed .float-project-chevron {
+  display: none !important;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-actions,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-actions {
+  width: 100%;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid var(--moat-border-light);
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-icon,
+.float-moat.float-moat-left.float-moat-collapsed .float-icon,
+.float-moat.float-moat-right.float-moat-collapsed .float-tools-icon,
+.float-moat.float-moat-left.float-moat-collapsed .float-tools-icon,
+.float-moat.float-moat-right.float-moat-collapsed .float-project-folder-icon,
+.float-moat.float-moat-left.float-moat-collapsed .float-project-folder-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-project-indicator,
+.float-moat.float-moat-left.float-moat-collapsed .float-project-indicator {
+  position: absolute;
+  top: 8px;
+  right: 9px;
+  width: 7px;
+  height: 7px;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-project-dropdown,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-project-dropdown {
+  position: relative;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-tabs-below-header,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-tabs-below-header {
+  display: none !important;
 }
 
 /* Right position - Compact top bar layout */
@@ -1111,6 +1294,14 @@ body.float-drawing-mode * {
   transform: rotate(180deg);
 }
 
+.float-moat.float-moat-right.float-moat-collapsed .float-collapse-icon {
+  transform: rotate(90deg);
+}
+
+.float-moat.float-moat-left.float-moat-collapsed .float-collapse-icon {
+  transform: rotate(-90deg);
+}
+
 /* Drawbridge Logo Icon */
 .float-drawbridge-icon {
   width: 20px;
@@ -1377,6 +1568,12 @@ body.float-drawing-mode * {
   pointer-events: none;
 }
 
+.float-moat.float-moat-collapsed .float-moat-tabs-header.hidden,
+.float-moat.float-moat-collapsed .float-moat-tabs-below-header.hidden {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* Position-specific visibility rules */
 
 /* Right-docked position: show tabs below header, hide tabs in header */
@@ -1417,6 +1614,16 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-left .float-moat-tabs-below-header {
   display: block;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-tabs-header,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-tabs-header {
+  display: flex !important;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-tabs-below-header,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-tabs-below-header {
+  display: none !important;
 }
 
 /* Bottom-docked position: show tabs in header, hide tabs below header */

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -616,7 +616,7 @@ body.float-drawing-mode * {
   margin: 0 auto;
   width: 22px !important;
   height: 22px !important;
-  transform: translateX(3px);
+  transform: translateX(5px);
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-right-controls,
@@ -705,6 +705,7 @@ body.float-drawing-mode * {
   font-weight: 700;
   line-height: 22px;
   color: #ffffff;
+  transform: translateX(4px);
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-tools-dropdown,

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -616,7 +616,7 @@ body.float-drawing-mode * {
   margin: 0 auto;
   width: 22px !important;
   height: 22px !important;
-  transform: translateX(1px);
+  transform: translateX(3px);
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-right-controls,

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -29,6 +29,7 @@
   --moat-shadow-lg: rgba(0, 0, 0, 0.15);
   --moat-notification-bg: #1f2937;
   --moat-notification-text: #ffffff;
+  --moat-collapsed-bar-size: 49px;
   
   /* Scrollbar colors */
   --moat-scrollbar-track: transparent;
@@ -499,6 +500,26 @@ body.float-drawing-mode * {
   flex-direction: column;
 }
 
+.float-moat.float-moat-collapsed {
+  overflow: visible;
+}
+
+.float-moat.float-moat-collapsed .float-moat-top-bar {
+  min-height: var(--moat-collapsed-bar-size);
+  box-sizing: border-box;
+}
+
+.float-moat.float-moat-collapsed .float-moat-top-bar button {
+  cursor: pointer;
+}
+
+.float-moat.float-moat-collapsed .float-moat-queue,
+.float-moat.float-moat-collapsed .float-moat-tabs-header,
+.float-moat.float-moat-collapsed .float-moat-tabs-below-header,
+.float-moat.float-moat-collapsed .float-header-notifications {
+  display: none !important;
+}
+
 /* Right position (default) */
 .float-moat.float-moat-right {
   top: 0;
@@ -525,6 +546,13 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-left.float-moat-visible {
   left: 0;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed,
+.float-moat.float-moat-left.float-moat-collapsed {
+  height: var(--moat-collapsed-bar-size);
+  min-height: var(--moat-collapsed-bar-size);
+  max-height: var(--moat-collapsed-bar-size);
 }
 
 /* Right position - Compact top bar layout */
@@ -739,6 +767,17 @@ body.float-drawing-mode * {
   transform: translateY(0);
 }
 
+.float-moat.float-moat-bottom.float-moat-collapsed {
+  min-height: var(--moat-collapsed-bar-size);
+  height: var(--moat-collapsed-bar-size);
+  max-height: var(--moat-collapsed-bar-size);
+}
+
+.float-moat.float-moat-bottom.float-moat-collapsed .float-moat-top-bar {
+  border-top: 1px solid var(--moat-border);
+  border-bottom: none;
+}
+
 /* Bottom position - Top control bar */
 .float-moat.float-moat-bottom .float-moat-top-bar {
   display: flex;
@@ -780,6 +819,11 @@ body.float-drawing-mode * {
   min-width: 0;
   max-width: calc(50% - 120px); /* Ensure space for centered tabs */
   overflow: hidden;
+}
+
+.float-moat.float-moat-bottom.float-moat-collapsed .float-moat-header,
+.float-moat.float-moat-bottom.float-moat-collapsed .float-moat-right-controls {
+  max-width: none;
 }
 
 .float-moat.float-moat-bottom .float-moat-project-status {
@@ -1057,6 +1101,14 @@ body.float-drawing-mode * {
   height: 12px;
   fill: currentColor;
   transition: all 0.2s;
+}
+
+.float-collapse-icon {
+  transform-origin: center;
+}
+
+.float-moat.float-moat-collapsed .float-collapse-icon {
+  transform: rotate(180deg);
 }
 
 /* Drawbridge Logo Icon */

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -1330,6 +1330,14 @@ body.float-drawing-mode * {
   transform-origin: center;
 }
 
+.float-moat.float-moat-right:not(.float-moat-collapsed) .float-collapse-icon {
+  transform: rotate(-90deg);
+}
+
+.float-moat.float-moat-left:not(.float-moat-collapsed) .float-collapse-icon {
+  transform: rotate(90deg);
+}
+
 .float-moat.float-moat-collapsed .float-collapse-icon {
   transform: rotate(180deg);
 }

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -571,7 +571,7 @@ body.float-drawing-mode * {
   width: 100%;
   height: 100vh;
   min-height: 100vh;
-  padding: 10px 8px;
+  padding: 12px 8px;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
@@ -602,30 +602,41 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-header h3,
 .float-moat.float-moat-left.float-moat-collapsed .float-moat-header h3 {
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   margin: 0 auto;
   justify-content: center;
   align-items: center;
+  padding-left: 1px;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-drawbridge-icon,
 .float-moat.float-moat-left.float-moat-collapsed .float-drawbridge-icon {
   display: block;
   margin: 0 auto;
-  width: 20px !important;
-  height: 20px !important;
+  width: 22px !important;
+  height: 22px !important;
+  transform: translateX(1px);
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-right-controls,
 .float-moat.float-moat-left.float-moat-collapsed .float-moat-right-controls {
-  flex: 1 1 auto;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 6px;
-  min-height: 0;
-  overflow: visible;
+  display: contents;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-header,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-header {
+  order: 1;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-project-status-container,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-project-status-container {
+  order: 2;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-new-comment-container,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-new-comment-container {
+  order: 3;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-tabs-header,
@@ -634,6 +645,7 @@ body.float-drawing-mode * {
   width: 100%;
   flex: none;
   justify-content: center;
+  order: 4;
   margin: 0;
 }
 
@@ -647,7 +659,7 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-group,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-group {
-  width: 32px;
+  width: 22px;
   padding: 0;
   gap: 7px;
   flex-direction: column;
@@ -659,22 +671,23 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-btn,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-btn {
-  width: 32px;
-  height: 32px;
+  width: 22px;
+  height: 22px;
   padding: 0;
   flex: none;
   font-size: 0;
   line-height: 1;
-  border: 1px solid transparent;
-  border-radius: 8px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
   box-shadow: none;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-btn.float-tab-active,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-btn.float-tab-active {
-  background: var(--moat-bg-secondary);
-  border-color: var(--moat-border);
-  box-shadow: 0 1px 3px var(--moat-shadow);
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-badge,
@@ -729,6 +742,7 @@ body.float-drawing-mode * {
   width: 32px;
   flex-direction: column;
   gap: 6px;
+  order: 99;
   margin-top: auto;
   padding-top: 10px;
   border-top: 1px solid var(--moat-border-light);

--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -30,7 +30,7 @@
   --moat-notification-bg: #1f2937;
   --moat-notification-text: #ffffff;
   --moat-collapsed-bar-size: 49px;
-  --moat-collapsed-rail-size: 56px;
+  --moat-collapsed-rail-size: 48px;
   
   /* Scrollbar colors */
   --moat-scrollbar-track: transparent;
@@ -571,11 +571,11 @@ body.float-drawing-mode * {
   width: 100%;
   height: 100vh;
   min-height: 100vh;
-  padding: 10px 7px;
+  padding: 10px 8px;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   border-bottom: none;
 }
 
@@ -602,10 +602,19 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-header h3,
 .float-moat.float-moat-left.float-moat-collapsed .float-moat-header h3 {
-  width: 100%;
-  height: 40px;
+  width: 32px;
+  height: 32px;
+  margin: 0 auto;
   justify-content: center;
   align-items: center;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-drawbridge-icon,
+.float-moat.float-moat-left.float-moat-collapsed .float-drawbridge-icon {
+  display: block;
+  margin: 0 auto;
+  width: 20px !important;
+  height: 20px !important;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-right-controls,
@@ -614,7 +623,7 @@ body.float-drawing-mode * {
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  gap: 8px;
+  gap: 6px;
   min-height: 0;
   overflow: visible;
 }
@@ -624,14 +633,23 @@ body.float-drawing-mode * {
   display: flex !important;
   width: 100%;
   flex: none;
+  justify-content: center;
   margin: 0;
+}
+
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-new-comment-container,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-new-comment-container,
+.float-moat.float-moat-right.float-moat-collapsed .float-moat-project-status-container,
+.float-moat.float-moat-left.float-moat-collapsed .float-moat-project-status-container {
+  display: flex;
+  justify-content: center;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-group,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-group {
-  width: 100%;
+  width: 32px;
   padding: 0;
-  gap: 8px;
+  gap: 7px;
   flex-direction: column;
   background: transparent;
   border: none;
@@ -641,8 +659,8 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-btn,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-btn {
-  width: 100%;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   padding: 0;
   flex: none;
   font-size: 0;
@@ -662,17 +680,17 @@ body.float-drawing-mode * {
 .float-moat.float-moat-right.float-moat-collapsed .float-tab-badge,
 .float-moat.float-moat-left.float-moat-collapsed .float-tab-badge {
   position: static;
-  width: 28px;
-  min-width: 28px;
-  height: 28px;
+  width: 22px;
+  min-width: 22px;
+  height: 22px;
   padding: 0;
   border-radius: 999px;
   display: inline-flex !important;
   align-items: center;
   justify-content: center;
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 700;
-  line-height: 28px;
+  line-height: 22px;
   color: #ffffff;
 }
 
@@ -682,13 +700,13 @@ body.float-drawing-mode * {
 .float-moat.float-moat-left.float-moat-collapsed .float-moat-project-dropdown,
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-actions button,
 .float-moat.float-moat-left.float-moat-collapsed .float-moat-actions button {
-  width: 100%;
+  width: 32px;
   max-width: none;
   min-width: 0;
-  height: 40px;
+  height: 32px;
   padding: 0;
   justify-content: center;
-  border-radius: 8px;
+  border-radius: 7px;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-tools-text,
@@ -708,11 +726,11 @@ body.float-drawing-mode * {
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-actions,
 .float-moat.float-moat-left.float-moat-collapsed .float-moat-actions {
-  width: 100%;
+  width: 32px;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   margin-top: auto;
-  padding-top: 12px;
+  padding-top: 10px;
   border-top: 1px solid var(--moat-border-light);
 }
 
@@ -722,17 +740,17 @@ body.float-drawing-mode * {
 .float-moat.float-moat-left.float-moat-collapsed .float-tools-icon,
 .float-moat.float-moat-right.float-moat-collapsed .float-project-folder-icon,
 .float-moat.float-moat-left.float-moat-collapsed .float-project-folder-icon {
-  width: 16px;
-  height: 16px;
+  width: 12px;
+  height: 12px;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-project-indicator,
 .float-moat.float-moat-left.float-moat-collapsed .float-project-indicator {
   position: absolute;
-  top: 8px;
-  right: 9px;
-  width: 7px;
-  height: 7px;
+  top: 7px;
+  right: 7px;
+  width: 6px;
+  height: 6px;
 }
 
 .float-moat.float-moat-right.float-moat-collapsed .float-moat-project-dropdown,

--- a/chrome-extension/moat.js
+++ b/chrome-extension/moat.js
@@ -1498,6 +1498,16 @@
         <span>Clear screenshots</span>
         <span class="float-badge clear-screenshots-badge" id="clearScreenshotsBadge" style="margin-left: auto; display: none;"></span>
       </div>
+      <div class="float-project-menu-item" data-action="delete-completed">
+        <svg style="width: 12px; height: 12px; fill: #6B7280;" viewBox="0 0 24 24">
+          <rect x="3" y="5" width="18" height="2"/>
+          <rect x="5" y="8" width="14" height="13" fill="none" stroke="#6B7280" stroke-width="2"/>
+          <rect x="8" y="11" width="2" height="7"/>
+          <rect x="14" y="11" width="2" height="7"/>
+        </svg>
+        <span>Delete completed tasks</span>
+        <span class="float-badge delete-completed-badge" id="deleteCompletedBadge" style="margin-left: auto; display: none;"></span>
+      </div>
       <div class="float-project-menu-item float-project-menu-divider" data-action="disconnect">
         <svg style="width: 12px; height: 12px; fill: #DC2626;" viewBox="0 0 24 24">
           <polygon points="2 13 1 13 1 11 2 11 2 9 3 9 3 8 4 8 4 7 5 7 5 6 7 6 7 5 15 5 15 6 14 6 14 7 13 7 13 6 11 6 11 7 9 7 9 8 8 8 8 9 7 9 7 11 6 11 6 13 7 13 7 14 6 14 6 15 5 15 5 16 3 16 3 15 2 15 2 13"/>
@@ -1526,11 +1536,17 @@
     
     // Update badge count for clear screenshots option
     if (canUseNewTaskSystem() && window.taskStore) {
-      const completedTasks = window.taskStore.getTasks().filter(t => t.status === 'done' && t.screenshotPath);
+      const allCompletedTasks = window.taskStore.getTasks().filter(t => t.status === 'done');
+      const completedTasks = allCompletedTasks.filter(t => t.screenshotPath);
       const badge = menu.querySelector('#clearScreenshotsBadge');
       if (badge && completedTasks.length > 0) {
         badge.textContent = completedTasks.length;
         badge.style.display = 'inline-block';
+      }
+      const deleteBadge = menu.querySelector('#deleteCompletedBadge');
+      if (deleteBadge && allCompletedTasks.length > 0) {
+        deleteBadge.textContent = allCompletedTasks.length;
+        deleteBadge.style.display = 'inline-flex';
       }
     }
     
@@ -1547,6 +1563,8 @@
           refreshTasks(false); // Manual refresh should show notifications
         } else if (action === 'clear-screenshots') {
           await clearCompletedScreenshots();
+        } else if (action === 'delete-completed') {
+          await deleteCompletedTasks();
         }
       }
       menu.remove();
@@ -1835,6 +1853,47 @@
     }
   }
 
+  // Delete completed tasks and associated screenshots
+  async function deleteCompletedTasks() {
+    if (!canUseNewTaskSystem() || !window.taskStore) {
+      showNotification('Completed tasks can only be deleted in new task system', 'error');
+      return;
+    }
+
+    try {
+      const completedTasks = window.taskStore.getTasks().filter(t => t.status === 'done');
+
+      if (completedTasks.length === 0) {
+        showNotification('No completed tasks found', 'info');
+        return;
+      }
+
+      const confirmed = await showDeleteCompletedTasksConfirmation(completedTasks.length);
+      if (!confirmed) return;
+
+      showNotification('Deleting completed tasks...', 'info');
+
+      const result = await window.taskStore.deleteCompletedTasks();
+
+      if (result.success) {
+        if (window.markdownGenerator) {
+          const allTasks = window.taskStore.getAllTasksChronological();
+          await window.markdownGenerator.rebuildMarkdownFile(allTasks);
+        }
+
+        const message = `Deleted ${result.deletedCount} completed task${result.deletedCount !== 1 ? 's' : ''}`;
+        showNotification(message, 'success');
+        console.log('✅ Completed tasks deleted:', result);
+        await refreshTasks(true);
+      } else {
+        showNotification('Failed to delete completed tasks', 'error');
+      }
+    } catch (error) {
+      console.error('Error deleting completed tasks:', error);
+      showNotification(`Error: ${error.message}`, 'error');
+    }
+  }
+
   // Show confirmation dialog for clearing screenshots
   function showClearScreenshotsConfirmation(count) {
     return new Promise((resolve) => {
@@ -1856,6 +1915,48 @@
             </button>
             <button class="float-modal-button float-modal-button-danger" data-action="confirm">
               Clear Screenshots
+            </button>
+          </div>
+        </div>
+      `;
+
+      document.body.appendChild(modal);
+
+      modal.addEventListener('click', (e) => {
+        const button = e.target.closest('[data-action]');
+        if (button) {
+          const action = button.dataset.action;
+          modal.remove();
+          resolve(action === 'confirm');
+        } else if (e.target === modal) {
+          modal.remove();
+          resolve(false);
+        }
+      });
+    });
+  }
+
+  // Show confirmation dialog for deleting completed tasks
+  function showDeleteCompletedTasksConfirmation(count) {
+    return new Promise((resolve) => {
+      const modal = document.createElement('div');
+      modal.className = 'float-modal-overlay';
+      modal.innerHTML = `
+        <div class="float-modal" style="max-width: 400px;">
+          <h2 style="margin: 0 0 12px 0; font-size: 18px; font-weight: 600; color: var(--moat-text-primary);">
+            Delete Completed Tasks?
+          </h2>
+          <p style="margin: 0 0 20px 0; font-size: 14px; color: var(--moat-text-secondary); line-height: 1.5;">
+            This will delete <strong>${count} completed task${count !== 1 ? 's' : ''}</strong> and any associated screenshots.
+            <br><br>
+            Drawbridge will create a backup JSON file before deleting.
+          </p>
+          <div style="display: flex; gap: 8px; justify-content: flex-end;">
+            <button class="float-modal-button float-modal-button-secondary" data-action="cancel">
+              Cancel
+            </button>
+            <button class="float-modal-button float-modal-button-danger" data-action="confirm">
+              Delete Tasks
             </button>
           </div>
         </div>
@@ -2652,6 +2753,7 @@
     if (!moat) return;
     
     console.log('Moat: Rendering empty sidebar');
+    updateTabBadges([]);
     const queueContainer = moat.querySelector('.float-moat-queue');
     const tabsHeaderContainer = moat.querySelector('.float-moat-tabs-header');
     const tabsBelowContainer = moat.querySelector('.float-moat-tabs-below-header');
@@ -3008,12 +3110,161 @@
   }
   
   // Render simple task item without emojis
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function getTaskFromRenderedId(id) {
+    if (canUseNewTaskSystem() && window.taskStore) {
+      return window.taskStore.getTaskById(id);
+    }
+
+    const queue = JSON.parse(localStorage.getItem('moat.queue') || '[]');
+    const annotation = queue.find(a => a.id === id);
+    return annotation ? convertAnnotationToTask(annotation) : null;
+  }
+
+  function formatTaskPrompt(task) {
+    const lines = [
+      `Drawbridge task: ${task.title || 'UI annotation'}`,
+      '',
+      task.comment || task.content || '',
+      '',
+      `Status: ${task.status || 'to do'}`,
+      `URL: ${task.pageUrl || window.location.href || 'Unknown'}`,
+      `Selector: ${task.selector || 'Freeform rectangle'}`,
+      `Screenshot: ${task.screenshotPath || 'None'}`
+    ];
+
+    if (task.boundingRect) {
+      lines.push(`Bounds: ${JSON.stringify(task.boundingRect)}`);
+    }
+
+    return lines.filter((line, index) => line || index < 3).join('\n');
+  }
+
+  async function copyTextToClipboard(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    document.execCommand('copy');
+    textarea.remove();
+  }
+
+  async function copyTaskPrompt(id) {
+    const task = getTaskFromRenderedId(id);
+    if (!task) {
+      showNotification('Task not found for copy', 'error');
+      return;
+    }
+
+    try {
+      await copyTextToClipboard(formatTaskPrompt(task));
+      showNotification('Task prompt copied', 'success');
+    } catch (error) {
+      console.error('Could not copy task prompt:', error);
+      showNotification('Could not copy task prompt', 'error');
+    }
+  }
+
+  function showTaskDetails(id) {
+    const task = getTaskFromRenderedId(id);
+    if (!task) {
+      showNotification('Task not found', 'error');
+      return;
+    }
+
+    const prompt = formatTaskPrompt(task);
+    const json = JSON.stringify(task, null, 2);
+    const modal = document.createElement('div');
+    modal.className = 'float-modal-overlay';
+    modal.innerHTML = `
+      <div class="float-modal float-task-detail-modal">
+        <div class="float-task-detail-header">
+          <h2>${escapeHtml(task.title || 'Task details')}</h2>
+          <button class="float-task-detail-close" data-action="close" title="Close">
+            <svg class="float-icon" viewBox="0 0 24 24">
+              <polygon points="15 13 16 13 16 14 17 14 17 15 18 15 18 16 19 16 19 17 20 17 20 18 21 18 21 19 22 19 22 20 21 20 21 21 20 21 20 22 19 22 19 21 18 21 18 20 17 20 17 19 16 19 16 18 15 18 15 17 14 17 14 16 13 16 13 15 11 15 11 16 10 16 10 17 9 17 9 18 8 18 8 19 7 19 7 20 6 20 6 21 5 21 5 22 4 22 4 21 3 21 3 20 2 20 2 19 3 19 3 18 4 18 4 17 5 17 5 16 6 16 6 15 7 15 7 14 8 14 8 13 9 13 9 11 8 11 8 10 7 10 7 9 6 9 6 8 5 8 5 7 4 7 4 6 3 6 3 5 2 5 2 4 3 4 3 3 4 3 4 2 5 2 5 3 6 3 6 4 7 4 7 5 8 5 8 6 9 6 9 7 10 7 10 8 11 8 11 9 13 9 13 8 14 8 14 7 15 7 15 6 16 6 16 5 17 5 17 4 18 4 18 3 19 3 19 2 20 2 20 3 21 3 21 4 22 4 22 5 21 5 21 6 20 6 20 7 19 7 19 8 18 8 18 9 17 9 17 10 16 10 16 11 15 11 15 13"/>
+            </svg>
+          </button>
+        </div>
+        <div class="float-task-detail-grid">
+          <div>
+            <span>Status</span>
+            <strong>${escapeHtml(task.status || 'to do')}</strong>
+          </div>
+          <div>
+            <span>Created</span>
+            <strong>${escapeHtml(formatTimeAgo(task.timestamp || task.createdAt))}</strong>
+          </div>
+          <div>
+            <span>Selector</span>
+            <code>${escapeHtml(task.selector || 'Freeform rectangle')}</code>
+          </div>
+          <div>
+            <span>Screenshot</span>
+            <code>${escapeHtml(task.screenshotPath || 'None')}</code>
+          </div>
+        </div>
+        <label class="float-task-detail-label">Comment</label>
+        <div class="float-task-detail-text">${escapeHtml(task.comment || task.content || 'No content available')}</div>
+        <label class="float-task-detail-label">Assistant Prompt</label>
+        <pre class="float-task-detail-pre">${escapeHtml(prompt)}</pre>
+        <details class="float-task-detail-json">
+          <summary>Raw JSON</summary>
+          <pre>${escapeHtml(json)}</pre>
+        </details>
+        <div class="float-modal-actions">
+          <button class="float-modal-button float-modal-button-secondary" data-action="copy-json">Copy JSON</button>
+          <button class="float-modal-button float-modal-confirm" data-action="copy-prompt">Copy Prompt</button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(modal);
+
+    modal.addEventListener('click', async (e) => {
+      const button = e.target.closest('[data-action]');
+      if (!button) {
+        if (e.target === modal) modal.remove();
+        return;
+      }
+
+      const action = button.dataset.action;
+      if (action === 'close') {
+        modal.remove();
+      } else if (action === 'copy-prompt') {
+        await copyTextToClipboard(prompt);
+        showNotification('Task prompt copied', 'success');
+      } else if (action === 'copy-json') {
+        await copyTextToClipboard(json);
+        showNotification('Task JSON copied', 'success');
+      }
+    });
+  }
+
   function renderSimpleTaskItem(task) {
-    const isCompleted = ['done', 'resolved'].includes(task.status);
-    const statusClass = `float-status-${task.status.replace(/\s+/g, '-')}`;
-    const statusText = getStatusText(task.status);
+    const taskStatus = task.status || 'to do';
+    const isCompleted = ['done', 'resolved'].includes(taskStatus);
+    const statusClass = `float-status-${taskStatus.replace(/\s+/g, '-')}`;
     const timeAgo = formatTimeAgo(task.timestamp || task.createdAt);
     const hasScreenshot = task.screenshotPath && window.directoryHandle;
+    const taskContent = task.content || task.comment || 'No content available';
+    const taskSelector = task.selector || '';
     
     // Calculate thumbnail focus point based on click position in context viewport
     let thumbnailStyle = '';
@@ -3040,19 +3291,35 @@
           <div class="float-moat-item-content-area">
             <div class="float-moat-item-header">
               <div class="float-moat-status-and-time">
-                <span class="float-moat-time">${timeAgo}</span>
+                <span class="float-moat-time">${escapeHtml(timeAgo)}</span>
               </div>
-              ${!hasScreenshot && (task.format === 'current' || !task.format) ? 
-                `<button class="float-moat-remove" data-id="${task.id}" title="Remove task">
+              <div class="float-moat-item-actions">
+                <button class="float-moat-action-btn float-moat-details" data-id="${escapeHtml(task.id)}" title="View task details">
+                  <svg class="float-icon" viewBox="0 0 24 24">
+                    <rect x="4" y="3" width="16" height="18" fill="none" stroke="currentColor" stroke-width="2"/>
+                    <rect x="8" y="8" width="8" height="2"/>
+                    <rect x="8" y="12" width="8" height="2"/>
+                    <rect x="8" y="16" width="5" height="2"/>
+                  </svg>
+                </button>
+                <button class="float-moat-action-btn float-moat-copy" data-id="${escapeHtml(task.id)}" title="Copy task prompt">
+                  <svg class="float-icon" viewBox="0 0 24 24">
+                    <rect x="8" y="8" width="11" height="13" fill="none" stroke="currentColor" stroke-width="2"/>
+                    <polyline points="5 16 5 3 16 3 16 6" fill="none" stroke="currentColor" stroke-width="2"/>
+                  </svg>
+                </button>
+                ${!hasScreenshot && (task.format === 'current' || !task.format) ? 
+                  `<button class="float-moat-action-btn float-moat-remove" data-id="${escapeHtml(task.id)}" title="Remove task">
                   <svg class="float-icon" viewBox="0 0 24 24">
                     <polygon points="15 13 16 13 16 14 17 14 17 15 18 15 18 16 19 16 19 17 20 17 20 18 21 18 21 19 22 19 22 20 21 20 21 21 20 21 20 22 19 22 19 21 18 21 18 20 17 20 17 19 16 19 16 18 15 18 15 17 14 17 14 16 13 16 13 15 11 15 11 16 10 16 10 17 9 17 9 18 8 18 8 19 7 19 7 20 6 20 6 21 5 21 5 22 4 22 4 21 3 21 3 20 2 20 2 19 3 19 3 18 4 18 4 17 5 17 5 16 6 16 6 15 7 15 7 14 8 14 8 13 9 13 9 11 8 11 8 10 7 10 7 9 6 9 6 8 5 8 5 7 4 7 4 6 3 6 3 5 2 5 2 4 3 4 3 3 4 3 4 2 5 2 5 3 6 3 6 4 7 4 7 5 8 5 8 6 9 6 9 7 10 7 10 8 11 8 11 9 13 9 13 8 14 8 14 7 15 7 15 6 16 6 16 5 17 5 17 4 18 4 18 3 19 3 19 2 20 2 20 3 21 3 21 4 22 4 22 5 21 5 21 6 20 6 20 7 19 7 19 8 18 8 18 9 17 9 17 10 16 10 16 11 15 11 15 13"/>
                   </svg>
-                </button>` : 
-                ''
-              }
+                  </button>` : 
+                  ''
+                }
+              </div>
             </div>
-            <div class="float-moat-content">${task.content || task.comment || 'No content available'}</div>
-            ${task.selector ? `<span class="float-moat-selector">${task.selector}</span>` : ''}
+            <div class="float-moat-content">${escapeHtml(taskContent)}</div>
+            ${taskSelector ? `<span class="float-moat-selector">${escapeHtml(taskSelector)}</span>` : ''}
           </div>
           ${hasScreenshot ? 
             `<div class="float-moat-thumbnail-container" data-task-id="${task.id}">
@@ -3233,8 +3500,8 @@
       
       // Click to highlight element (only for current session items)
       item.addEventListener('click', (e) => {
-        // Don't trigger if clicking remove button or thumbnail
-        if (e.target.closest('.float-moat-remove')) return;
+        // Don't trigger if clicking task actions or thumbnail
+        if (e.target.closest('.float-moat-action-btn')) return;
         if (e.target.closest('.float-moat-thumbnail-container')) return;
         
         const dataType = item.dataset.type;
@@ -3273,6 +3540,22 @@
         e.stopPropagation();
         console.log('🗑️ Moat: Remove button clicked for task ID:', btn.dataset.id);
         await removeAnnotation(btn.dataset.id);
+      });
+    });
+
+    // Detail buttons
+    queueContainer.querySelectorAll('.float-moat-details').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        showTaskDetails(btn.dataset.id);
+      });
+    });
+
+    // Copy buttons
+    queueContainer.querySelectorAll('.float-moat-copy').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        await copyTaskPrompt(btn.dataset.id);
       });
     });
     

--- a/chrome-extension/moat.js
+++ b/chrome-extension/moat.js
@@ -1378,10 +1378,12 @@
   // Shared function for positioning menus with smart placement
   function positionMenu(menu, button) {
     const rect = button.getBoundingClientRect();
+    const isCollapsedSideRail = isCollapsed && (moatPosition === 'left' || moatPosition === 'right');
     
     // Append menu off-screen first to measure its height
     menu.style.position = 'fixed';
     menu.style.top = '-9999px';
+    menu.style.left = '';
     menu.style.right = '0';
     menu.style.opacity = '0';
     menu.style.transform = 'translateY(-8px) scale(0.95)';
@@ -1389,16 +1391,33 @@
     
     // Get actual menu height
     const menuHeight = menu.offsetHeight || 200; // Fallback estimate
+    const menuWidth = menu.offsetWidth || 220;
     
     // Calculate position above button, ensuring it doesn't go off-screen
     const spaceAbove = rect.top;
     const spaceBelow = window.innerHeight - rect.bottom;
-    const maxHeight = Math.min(menuHeight, spaceAbove - 10, window.innerHeight - 20);
+    const maxHeight = Math.max(96, Math.min(menuHeight, Math.max(spaceAbove - 10, spaceBelow - 10), window.innerHeight - 20));
     
     // Always use 4px spacing (ensures 4px from top of plugin drawer when docked at bottom)
     const spacing = 4;
     
-    if (spaceAbove >= menuHeight + spacing || spaceAbove > spaceBelow) {
+    if (isCollapsedSideRail) {
+      const top = Math.min(
+        Math.max(10, rect.top),
+        Math.max(10, window.innerHeight - Math.min(menuHeight, maxHeight) - 10)
+      );
+      menu.style.top = `${top}px`;
+      menu.style.maxHeight = `${Math.min(menuHeight, window.innerHeight - 20)}px`;
+      menu.style.transformOrigin = moatPosition === 'left' ? 'top left' : 'top right';
+
+      if (moatPosition === 'left') {
+        menu.style.left = `${rect.right + spacing}px`;
+        menu.style.right = 'auto';
+      } else {
+        menu.style.right = `${window.innerWidth - rect.left + spacing}px`;
+        menu.style.left = 'auto';
+      }
+    } else if (spaceAbove >= menuHeight + spacing || spaceAbove > spaceBelow) {
       // Position above the button with 4px spacing
       menu.style.top = `${rect.top - menuHeight - spacing}px`;
       menu.style.maxHeight = `${maxHeight}px`;
@@ -1410,8 +1429,10 @@
       menu.style.transformOrigin = 'top right';
     }
     
-    menu.style.right = `${window.innerWidth - rect.right}px`;
-    menu.style.minWidth = `${rect.width}px`;
+    if (!isCollapsedSideRail) {
+      menu.style.right = `${window.innerWidth - rect.right}px`;
+    }
+    menu.style.minWidth = `${Math.max(rect.width, menuWidth)}px`;
     
     // Trigger animation
     requestAnimationFrame(() => {
@@ -2108,6 +2129,7 @@
 
   function updateTabBadges(allTasks) {
     if (!moat) return;
+    const showZeroBadges = isCollapsed && (moatPosition === 'left' || moatPosition === 'right');
     
     // Count tasks by status
     const counts = {
@@ -2129,9 +2151,9 @@
       // Update header badges
       const headerBadge = moat.querySelector(`#float-badge-${statusId}`);
       if (headerBadge) {
-        if (count > 0) {
+        if (count > 0 || showZeroBadges) {
           headerBadge.textContent = count;
-          headerBadge.style.display = 'inline-block';
+          headerBadge.style.display = showZeroBadges ? 'inline-flex' : 'inline-block';
         } else {
           headerBadge.style.display = 'none';
         }
@@ -2140,9 +2162,9 @@
       // Update below-header badges
       const belowBadge = moat.querySelector(`#float-badge-${statusId}-below`);
       if (belowBadge) {
-        if (count > 0) {
+        if (count > 0 || showZeroBadges) {
           belowBadge.textContent = count;
-          belowBadge.style.display = 'inline-block';
+          belowBadge.style.display = showZeroBadges ? 'inline-flex' : 'inline-block';
         } else {
           belowBadge.style.display = 'none';
         }
@@ -2218,6 +2240,18 @@
       collapseToggle.title = label;
       collapseToggle.setAttribute('aria-label', label);
     }
+
+    const showZeroBadges = isCollapsed && (moatPosition === 'left' || moatPosition === 'right');
+    ['todo', 'doing', 'done'].forEach(statusId => {
+      moat.querySelectorAll(`#float-badge-${statusId}, #float-badge-${statusId}-below`).forEach(badge => {
+        if (showZeroBadges && (!badge.textContent || badge.style.display === 'none')) {
+          badge.textContent = '0';
+          badge.style.display = 'inline-flex';
+        } else if (!showZeroBadges && badge.textContent === '0') {
+          badge.style.display = 'none';
+        }
+      });
+    });
   }
 
   function setMoatCollapsed(collapsed, persist = true) {
@@ -2257,6 +2291,8 @@
     } else {
       moat.classList.add('float-moat-right');
     }
+
+    updateCollapsedControls();
     
     // Note: Position button has been replaced with more button
     // Position-specific functionality is now handled through the more menu

--- a/chrome-extension/moat.js
+++ b/chrome-extension/moat.js
@@ -11,8 +11,10 @@
   let draggedItem = null;
   let moatPosition = 'bottom'; // 'right', 'bottom', or 'left' - default to bottom
   let currentTabFilter = 'to do'; // Currently selected tab filter
+  let isCollapsed = false;
   const MOAT_ELEMENT_ID = 'moat-moat';
   const MOAT_VISIBLE_CLASS = 'float-moat-visible';
+  const MOAT_COLLAPSED_CLASS = 'float-moat-collapsed';
   
   // ===== THUMBNAIL CACHE =====
   const thumbnailCache = new Map(); // Cache for loaded thumbnail URLs
@@ -1079,6 +1081,7 @@
         console.log('Moat: Found existing visible sidebar, adopting it for toggle');
         moat = existingMoat;
         isVisible = true;
+        isCollapsed = existingMoat.classList.contains(MOAT_COLLAPSED_CLASS);
         ownsMoatElement = false;
         return;
       }
@@ -1160,7 +1163,12 @@
                   <polygon points="14 19 15 19 15 21 14 21 14 22 13 22 13 23 11 23 11 22 10 22 10 21 9 21 9 19 10 19 10 18 11 18 11 17 13 17 13 18 14 18 14 19"/>
                 </svg>
               </button>
-              <button class="float-moat-close" title="Close Moat">
+              <button class="float-moat-collapse-toggle" title="Collapse Drawbridge" aria-label="Collapse Drawbridge">
+                <svg class="float-icon float-collapse-icon" viewBox="0 0 24 24">
+                  <polygon points="5 7 7 7 7 8 8 8 8 9 9 9 9 10 10 10 10 11 11 11 11 12 13 12 13 11 14 11 14 10 15 10 15 9 16 9 16 8 17 8 17 7 19 7 19 8 20 8 20 10 19 10 19 11 18 11 18 12 17 12 17 13 16 13 16 14 15 14 15 15 14 15 14 16 13 16 13 17 11 17 11 16 10 16 10 15 9 15 9 14 8 14 8 13 7 13 7 12 6 12 6 11 5 11 5 10 4 10 4 8 5 8 5 7"/>
+                </svg>
+              </button>
+              <button class="float-moat-close" title="Close Drawbridge" aria-label="Close Drawbridge">
                 <svg class="float-icon" viewBox="0 0 24 24">
                   <polygon points="15 13 16 13 16 14 17 14 17 15 18 15 18 16 19 16 19 17 20 17 20 18 21 18 21 19 22 19 22 20 21 20 21 21 20 21 20 22 19 22 19 21 18 21 18 20 17 20 17 19 16 19 16 18 15 18 15 17 14 17 14 16 13 16 13 15 11 15 11 16 10 16 10 17 9 17 9 18 8 18 8 19 7 19 7 20 6 20 6 21 5 21 5 22 4 22 4 21 3 21 3 20 2 20 2 19 3 19 3 18 4 18 4 17 5 17 5 16 6 16 6 15 7 15 7 14 8 14 8 13 9 13 9 11 8 11 8 10 7 10 7 9 6 9 6 8 5 8 5 7 4 7 4 6 3 6 3 5 2 5 2 4 3 4 3 3 4 3 4 2 5 2 5 3 6 3 6 4 7 4 7 5 8 5 8 6 9 6 9 7 10 7 10 8 11 8 11 9 13 9 13 8 14 8 14 7 15 7 15 6 16 6 16 5 17 5 17 4 18 4 18 3 19 3 19 2 20 2 20 3 21 3 21 4 22 4 22 5 21 5 21 6 20 6 20 7 19 7 19 8 18 8 18 9 17 9 17 10 16 10 16 11 15 11 15 13"/>
                 </svg>
@@ -1221,7 +1229,15 @@
     console.log('Moat: Sidebar element added to DOM');
     
     // Event listeners
-    moat.querySelector('.float-moat-close').addEventListener('click', hideMoat);
+    moat.querySelector('.float-moat-close').addEventListener('click', hideMoatCompletely);
+
+    const collapseToggle = moat.querySelector('.float-moat-collapse-toggle');
+    if (collapseToggle) {
+      collapseToggle.addEventListener('click', function(e) {
+        e.stopPropagation();
+        toggleMoatCollapsed();
+      });
+    }
     
     // Tools dropdown button functionality
     const toolsDropdown = moat.querySelector('.float-moat-tools-dropdown');
@@ -2187,6 +2203,40 @@
     console.log('Moat: toggleMoatPosition called (legacy function)');
   }
 
+  function updateCollapsedControls() {
+    if (!moat) return;
+
+    const closeButton = moat.querySelector('.float-moat-close');
+    if (closeButton) {
+      closeButton.title = 'Close Drawbridge';
+      closeButton.setAttribute('aria-label', 'Close Drawbridge');
+    }
+
+    const collapseToggle = moat.querySelector('.float-moat-collapse-toggle');
+    if (collapseToggle) {
+      const label = isCollapsed ? 'Expand Drawbridge' : 'Collapse Drawbridge';
+      collapseToggle.title = label;
+      collapseToggle.setAttribute('aria-label', label);
+    }
+  }
+
+  function setMoatCollapsed(collapsed, persist = true) {
+    isCollapsed = collapsed;
+
+    if (moat) {
+      moat.classList.toggle(MOAT_COLLAPSED_CLASS, collapsed);
+      updateCollapsedControls();
+    }
+
+    if (persist) {
+      localStorage.setItem('moat.collapsed', collapsed ? 'true' : 'false');
+    }
+  }
+
+  function getSavedCollapsedState() {
+    return localStorage.getItem('moat.collapsed') === 'true';
+  }
+
   // Set Moat position
   function setMoatPosition(position) {
     moatPosition = position;
@@ -2230,7 +2280,7 @@
     
     if (savedVisibility === 'true') {
       console.log('Moat: Auto-showing moat based on saved state');
-      await showMoat();
+      await showMoat({ collapsed: getSavedCollapsedState() });
     } else {
       console.log('Moat: Moat will remain hidden based on saved state');
     }
@@ -2287,6 +2337,7 @@
     // Check every 2 seconds if moat is still in DOM when it should be visible
     setInterval(() => {
       const savedVisibility = localStorage.getItem('moat.visible');
+      const shouldBeCollapsed = getSavedCollapsedState();
       if (savedVisibility === 'true') {
         // Check if moat element still exists in DOM
         const existingMoat = document.getElementById('moat-moat');
@@ -2294,10 +2345,15 @@
           console.log('Moat: Moat disappeared from DOM, recreating...');
           createMoat();
           moat.classList.add('float-moat-visible');
+          setMoatCollapsed(shouldBeCollapsed, false);
           showNotification('Moat restored');
         } else if (existingMoat && !existingMoat.classList.contains('float-moat-visible') && isVisible) {
           console.log('Moat: Moat exists but not visible, restoring visibility...');
           existingMoat.classList.add('float-moat-visible');
+          setMoatCollapsed(shouldBeCollapsed, false);
+        } else if (existingMoat && existingMoat.classList.contains('float-moat-visible')) {
+          moat = existingMoat;
+          setMoatCollapsed(shouldBeCollapsed, false);
         }
       }
     }, 2000);
@@ -2979,7 +3035,8 @@
   }
 
   // Show Moat
-  async function showMoat() {
+  async function showMoat(options = {}) {
+    const { collapsed = false } = options;
     console.log('Moat: showMoat called, moat exists:', !!moat);
     if (!moat) {
       console.log('Moat: Creating moat element...');
@@ -2988,6 +3045,7 @@
     console.log('Moat: Adding float-moat-visible class...');
     moat.classList.add(MOAT_VISIBLE_CLASS);
     isVisible = true;
+    setMoatCollapsed(collapsed);
     
     // PERSIST VISIBILITY STATE
     localStorage.setItem('moat.visible', 'true');
@@ -3004,12 +3062,39 @@
     await refreshTasks(); // Use refreshTasks for comprehensive loading
   }
 
-  // Hide Moat
-  function hideMoat() {
+  function expandMoat() {
+    return showMoat({ collapsed: false });
+  }
+
+  function collapseMoat() {
+    console.log('Moat: collapseMoat called, moat exists:', !!moat);
+    if (!moat) return;
+
+    closeAllMenus();
+    moat.classList.add(MOAT_VISIBLE_CLASS);
+    isVisible = true;
+    setMoatCollapsed(true);
+    localStorage.setItem('moat.visible', 'true');
+
+    removeElementHighlight();
+    resetFloatingAnimation();
+  }
+
+  function toggleMoatCollapsed() {
+    if (isCollapsed) {
+      expandMoat();
+      return;
+    }
+
+    collapseMoat();
+  }
+
+  function hideMoatCompletely() {
     console.log('Moat: hideMoat called, moat exists:', !!moat);
     if (moat) {
       moat.classList.remove(MOAT_VISIBLE_CLASS);
       isVisible = false;
+      setMoatCollapsed(false);
       
       // Remove any active element highlight
       removeElementHighlight();
@@ -3032,6 +3117,10 @@
     }
   }
 
+  function hideMoat() {
+    hideMoatCompletely();
+  }
+
   function syncMoatStateFromDom() {
     const existingMoat = document.getElementById(MOAT_ELEMENT_ID);
     if (!existingMoat) {
@@ -3049,6 +3138,7 @@
     }
 
     isVisible = moat.classList.contains(MOAT_VISIBLE_CLASS);
+    isCollapsed = moat.classList.contains(MOAT_COLLAPSED_CLASS);
   }
 
   // Toggle Moat
@@ -3057,10 +3147,10 @@
     console.log('Moat: toggleMoat called, current isVisible:', isVisible);
     if (isVisible) {
       console.log('Moat: Hiding sidebar...');
-      hideMoat();
+      hideMoatCompletely();
     } else {
       console.log('Moat: Showing sidebar...');
-      await showMoat();
+      await expandMoat();
     }
   }
 

--- a/chrome-extension/utils/taskStore.js
+++ b/chrome-extension/utils/taskStore.js
@@ -512,6 +512,46 @@ class TaskStore {
     }
 
     /**
+     * Delete all completed tasks and their screenshots, preserving a JSON backup first.
+     * @returns {Promise<Object>} Promise resolving to cleanup results
+     */
+    async deleteCompletedTasks() {
+        if (!this.directoryHandle) {
+            console.warn('Cannot delete completed tasks: no directory handle');
+            return { success: false, deletedCount: 0, screenshotErrors: [] };
+        }
+
+        const completedTasks = this.tasks.filter(task => task.status === TASK_STATUS.DONE);
+
+        if (completedTasks.length === 0) {
+            return { success: true, deletedCount: 0, message: 'No completed tasks to delete' };
+        }
+
+        await this.createBackup();
+
+        const screenshotErrors = [];
+        for (const task of completedTasks) {
+            if (task.screenshotPath) {
+                const deleted = await this.deleteScreenshotFile(task.screenshotPath);
+                if (!deleted) {
+                    screenshotErrors.push(task.id);
+                }
+            }
+        }
+
+        const completedIds = new Set(completedTasks.map(task => task.id));
+        this.tasks = this.tasks.filter(task => !completedIds.has(task.id));
+
+        await this.saveTasksToFile();
+
+        return {
+            success: true,
+            deletedCount: completedTasks.length,
+            screenshotErrors
+        };
+    }
+
+    /**
      * Create backup of current tasks before risky operations
      * @returns {Promise<boolean>} Promise resolving to backup success
      */


### PR DESCRIPTION
## Summary
- add a collapsible Drawbridge drawer rail for left, right, and bottom dock states
- keep project/tools controls and status counts available while collapsed
- document drawer layout options in the README

## Verification
- npm run build
- node --check chrome-extension/moat.js