### PR TITLE
Make task detail comments editable

### DIFF
--- a/chrome-extension/moat.css
+++ b/chrome-extension/moat.css
@@ -2567,6 +2567,13 @@ body.float-drawing-mode * {
   box-shadow: 0 1px 3px var(--moat-shadow);
 }
 
+.float-modal-button:disabled,
+.float-modal-button:disabled:hover {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+}
+
 /* Danger button for modals */
 .float-modal-button {
   padding: 10px 20px;
@@ -2673,6 +2680,7 @@ body.float-drawing-mode * {
 }
 
 .float-task-detail-text,
+.float-task-detail-comment,
 .float-task-detail-pre,
 .float-task-detail-json pre {
   border: 1px solid var(--moat-border);
@@ -2685,6 +2693,21 @@ body.float-drawing-mode * {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   margin: 0 0 16px 0;
+}
+
+.float-task-detail-comment {
+  display: block;
+  width: 100%;
+  min-height: 112px;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: inherit;
+  outline: none;
+}
+
+.float-task-detail-comment:focus {
+  border-color: var(--moat-accent);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
 .float-task-detail-json {

--- a/chrome-extension/moat.js
+++ b/chrome-extension/moat.js
@@ -3307,6 +3307,42 @@
     }
   }
 
+  async function saveTaskComment(id, comment) {
+    const nextComment = String(comment || '').trim();
+    if (!nextComment) {
+      throw new Error('Comment cannot be empty');
+    }
+
+    let updatedTask = null;
+
+    if (canUseNewTaskSystem() && window.taskStore) {
+      updatedTask = await window.taskStore.updateTaskCommentAndSave(id, nextComment);
+
+      if (updatedTask && window.markdownGenerator) {
+        const allTasks = window.taskStore.getAllTasksChronological();
+        await window.markdownGenerator.rebuildMarkdownFile(allTasks);
+      }
+    } else {
+      const queue = JSON.parse(localStorage.getItem('moat.queue') || '[]');
+      const annotation = queue.find(a => a.id === id);
+
+      if (annotation) {
+        annotation.content = nextComment;
+        annotation.comment = nextComment;
+        annotation.lastModified = Date.now();
+        localStorage.setItem('moat.queue', JSON.stringify(queue));
+        updatedTask = convertAnnotationToTask(annotation);
+      }
+    }
+
+    if (!updatedTask) {
+      return null;
+    }
+
+    await refreshTasks(true);
+    return updatedTask;
+  }
+
   function showTaskDetails(id) {
     const task = getTaskFromRenderedId(id);
     if (!task) {
@@ -3314,8 +3350,10 @@
       return;
     }
 
-    const prompt = formatTaskPrompt(task);
-    const json = JSON.stringify(task, null, 2);
+    let currentTask = task;
+    let currentPrompt = formatTaskPrompt(currentTask);
+    let currentJson = JSON.stringify(currentTask, null, 2);
+    const currentComment = task.comment || task.content || '';
     const modal = document.createElement('div');
     modal.className = 'float-modal-overlay';
     modal.innerHTML = `
@@ -3347,21 +3385,53 @@
           </div>
         </div>
         <label class="float-task-detail-label">Comment</label>
-        <div class="float-task-detail-text">${escapeHtml(task.comment || task.content || 'No content available')}</div>
+        <textarea class="float-task-detail-comment" data-field="comment">${escapeHtml(currentComment)}</textarea>
         <label class="float-task-detail-label">Assistant Prompt</label>
-        <pre class="float-task-detail-pre">${escapeHtml(prompt)}</pre>
+        <pre class="float-task-detail-pre" data-field="prompt">${escapeHtml(currentPrompt)}</pre>
         <details class="float-task-detail-json">
           <summary>Raw JSON</summary>
-          <pre>${escapeHtml(json)}</pre>
+          <pre data-field="json">${escapeHtml(currentJson)}</pre>
         </details>
         <div class="float-modal-actions">
           <button class="float-modal-button float-modal-button-secondary" data-action="copy-json">Copy JSON</button>
           <button class="float-modal-button float-modal-confirm" data-action="copy-prompt">Copy Prompt</button>
+          <button class="float-modal-button float-modal-confirm" data-action="save-comment" disabled>Save Comment</button>
         </div>
       </div>
     `;
 
     document.body.appendChild(modal);
+    const textarea = modal.querySelector('[data-field="comment"]');
+    const promptPre = modal.querySelector('[data-field="prompt"]');
+    const jsonPre = modal.querySelector('[data-field="json"]');
+    const saveButton = modal.querySelector('[data-action="save-comment"]');
+
+    function syncModalTask(nextTask) {
+      currentTask = nextTask;
+      currentPrompt = formatTaskPrompt(currentTask);
+      currentJson = JSON.stringify(currentTask, null, 2);
+
+      const nextComment = currentTask.comment || currentTask.content || '';
+      textarea.value = nextComment;
+      textarea.defaultValue = nextComment;
+      promptPre.textContent = currentPrompt;
+      jsonPre.textContent = currentJson;
+      saveButton.disabled = true;
+    }
+
+    function syncSaveButtonState() {
+      const nextComment = textarea.value.trim();
+      const savedComment = (textarea.defaultValue || '').trim();
+      saveButton.disabled = !nextComment || nextComment === savedComment;
+    }
+
+    textarea.addEventListener('input', syncSaveButtonState);
+    textarea.addEventListener('keydown', async (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && !saveButton.disabled) {
+        e.preventDefault();
+        saveButton.click();
+      }
+    });
 
     modal.addEventListener('click', async (e) => {
       const button = e.target.closest('[data-action]');
@@ -3374,11 +3444,33 @@
       if (action === 'close') {
         modal.remove();
       } else if (action === 'copy-prompt') {
-        await copyTextToClipboard(prompt);
+        await copyTextToClipboard(currentPrompt);
         showNotification('Task prompt copied', 'success');
       } else if (action === 'copy-json') {
-        await copyTextToClipboard(json);
+        await copyTextToClipboard(currentJson);
         showNotification('Task JSON copied', 'success');
+      } else if (action === 'save-comment') {
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Saving...';
+
+        try {
+          const updatedTask = await saveTaskComment(id, textarea.value);
+          if (!updatedTask) {
+            showNotification('Task not found for update', 'error');
+            syncSaveButtonState();
+            return;
+          }
+
+          syncModalTask(updatedTask);
+          showNotification('Task comment updated', 'success');
+        } catch (error) {
+          console.error('Could not update task comment:', error);
+          showNotification(error.message || 'Could not update task comment', 'error');
+          syncSaveButtonState();
+        } finally {
+          button.textContent = originalText;
+        }
       }
     });
   }

--- a/chrome-extension/utils/taskStore.js
+++ b/chrome-extension/utils/taskStore.js
@@ -260,6 +260,31 @@ class TaskStore {
     }
 
     /**
+     * Update a task comment
+     * @param {string} id - Task ID to update
+     * @param {string} comment - New comment value
+     * @returns {Object|null} Updated task object or null if not found
+     */
+    updateTaskComment(id, comment) {
+        const normalizedComment = String(comment || '').trim();
+        if (!normalizedComment) {
+            throw new Error('Task comment cannot be empty');
+        }
+
+        const task = this.getTaskById(id);
+        if (!task) {
+            return null;
+        }
+
+        task.comment = normalizedComment;
+        if (Object.prototype.hasOwnProperty.call(task, 'content')) {
+            task.content = normalizedComment;
+        }
+        task.lastModified = Date.now();
+        return task;
+    }
+
+    /**
      * Get task count statistics
      * @returns {Object} Statistics object with total, to do, doing, done counts
      */
@@ -376,6 +401,20 @@ class TaskStore {
      */
     async updateTaskStatusAndSave(id, status) {
         const task = this.updateTaskStatus(id, status);
+        if (task) {
+            await this.saveTasksToFile();
+        }
+        return task;
+    }
+
+    /**
+     * Update task comment and automatically save to file
+     * @param {string} id - Task ID to update
+     * @param {string} comment - New comment value
+     * @returns {Promise<Object|null>} Promise resolving to updated task or null if not found
+     */
+    async updateTaskCommentAndSave(id, comment) {
+        const task = this.updateTaskComment(id, comment);
         if (task) {
             await this.saveTasksToFile();
         }


### PR DESCRIPTION
## Summary
- make the task detail comment field editable with explicit save behavior
- persist edited comments through TaskStore or the legacy queue fallback
- refresh the queue card plus modal prompt/JSON after a successful save

## Verification
- node --check chrome-extension/moat.js
- node --check chrome-extension/utils/taskStore.js
- npm run build
- browser automation against the local demo confirmed the stored queue task, queue card text, and modal prompt all update after saving an edited comment